### PR TITLE
Add examples to schemas

### DIFF
--- a/src/schemas/amount_with_puzzlehash.yaml
+++ b/src/schemas/amount_with_puzzlehash.yaml
@@ -6,11 +6,14 @@ amount_with_puzzlehash:
   properties:
     amount:
       type: integer
+      example: 250000000000
       format: uint64
     puzzle_hash:
       type: string
+      example: "0x8f3dff600992a0b77aefbe8eb81dd4f233b9126f3b67557594b5a927d6e6d588"
       format: hex
     memos:
       type: array
+      example: []
       items:
         type: string

--- a/src/schemas/block_record.yaml
+++ b/src/schemas/block_record.yaml
@@ -1,92 +1,124 @@
 block_record:
   type: object
-  description: "This class is not included or hashed into the blockchain, but it is kept in memory as a more
-              efficient way to maintain data about the blockchain. This allows us to validate future blocks,
-              difficulty adjustments, etc, without saving the whole header block in memory."
-  properties: 
-    challenge_block_info_hash: 
+  description: This class is not included or hashed into the blockchain, but it is
+    kept in memory as a more efficient way to maintain data about the
+    blockchain. This allows us to validate future blocks, difficulty
+    adjustments, etc, without saving the whole header block in memory.
+  properties:
+    challenge_block_info_hash:
       type: string
-      description: Hash of challenge chain data, used to validate end of slots in the future.
-    challenge_vdf_output: 
+      example: "0x08dbc5c9f4676bad4cd2fad9b120afefdc107ffdd4066f73f14baf2a204f13df"
+      description: Hash of challenge chain data, used to validate end of slots in the
+        future.
+    challenge_vdf_output:
       type: object
       description: This is the intermediary VDF output at ip_iters in challenge chain.
-      properties: 
-        data: 
+      properties:
+        data:
           type: string
-    deficit: 
+          example: "0x0000af33fa9862d4e257498e9ba0c3cda09c1389d1fde0facd72ea26f5371ba94de\
+            b18137d95bd83b1c7afefba6293feda91d744d014c747e132db0247839e9bd00d79\
+            0c06f753a9d344c80c455a86ecd979c31687ece60748a5d62dca4723c3780d0906"
+    deficit:
       type: integer
+      example: 9
       format: uint8
-      description: A deficit of 16 is an overflow block after an infusion. Deficit of 15 is a challenge block.
-    farmer_puzzle_hash: 
+      description: A deficit of 16 is an overflow block after an infusion. Deficit of
+        15 is a challenge block.
+    farmer_puzzle_hash:
       type: string
-    fees: 
+      example: "0x8f5474dc460673a39c96bb0fdfea933f5d1269c138e47a67f07872c04803a4e7"
+    fees:
       type: integer
+      example: 0
       format: uint64
       nullable: true
       description: Transaction block (present iff is_transaction_block)
-    finished_challenge_slot_hashes: 
+    finished_challenge_slot_hashes:
       type: string
+      example: null
       format: nullable
       description: Slot (present iff this is the first SB in sub slot)
-    finished_infused_challenge_slot_hashes: 
+    finished_infused_challenge_slot_hashes:
       type: string
+      example: null
       format: nullable
       description: Slot (present iff this is the first SB in sub slot)
-    finished_reward_slot_hashes: 
+    finished_reward_slot_hashes:
       type: string
+      example: null
       format: nullable
       description: Slot (present iff this is the first SB in sub slot)
-    header_hash: 
+    header_hash:
       type: string
-    height: 
+      example: "0x3723909a7374c4c88cf00ab9b15365f4988f5bdb2d51bac23f6af939fe40f56c"
+    height:
       type: integer
+      example: 101
       format: uint32
-    infused_challenge_vdf_output: 
+    infused_challenge_vdf_output:
       type: string
+      example: '{"data":"0x0300a4bc6790208e73245df6a85b3f7beac0d17e73972b414a7f94cf1e3c3e9bb4a400516d368cfa8b1814f3b5163fe5a54a1fe35781f58290673c8d9f56cd23b94c138b21207d6aa6f3049f8ad805eb99b28292e06e748117e78e13598cee9945670100"}'
       format: nullable
-      description: This is the intermediary VDF output at ip_iters in infused cc, if deficit less than or equal to 3.
-    overflow: 
+      description: This is the intermediary VDF output at ip_iters in infused cc, if
+        deficit less than or equal to 3.
+    overflow:
       type: boolean
-    pool_puzzle_hash: 
+      example: false
+    pool_puzzle_hash:
       type: string
+      example: "0x8f5474dc460673a39c96bb0fdfea933f5d1269c138e47a67f07872c04803a4e7"
       description: Need to keep track of these because Coins are created in a future block.
-    prev_hash: 
+    prev_hash:
       type: string
-      description: Header hash of the previous block. Transaction block (present iff is_transaction_block).
-    prev_transaction_block_hash: 
+      example: "0x9a6c8728021574c5f3242370831b9fde7a0421f4448b4848276fe1652580c6a7"
+      description: Header hash of the previous block. Transaction block (present iff
+        is_transaction_block).
+    prev_transaction_block_hash:
       type: string
+      example: "0x6c94307cb88f37ca002936769246579824ecadc77fe1e445d31165e6958288e8"
       format: nullable
       description: Header hash of the previous transaction block
-    prev_transaction_block_height: 
+    prev_transaction_block_height:
       type: integer
+      example: 97
       format: int32
-    required_iters: 
+    required_iters:
       type: integer
+      example: 1045145
       format: int32
-    reward_claims_incorporated: 
+    reward_claims_incorporated:
       type: string
+      example: '[{"amount":1750000000000,"parent_coin_info":"0xccd5bb71183532bff220ba46c268991a00000000000000000000000000000061","puzzle_hash":"0x8f3dff600992a0b77aefbe8eb81dd4f233b9126f3b67557594b5a927d6e6d588"},{"amount":250000000000,"parent_coin_info":"0x3ff07eb358e8255a65c30a2dce0e5fbb00000000000000000000000000000061","puzzle_hash":"0x8f3dff600992a0b77aefbe8eb81dd4f233b9126f3b67557594b5a927d6e6d588"}]'
       format: nullable
-    reward_infusion_new_challenge: 
+    reward_infusion_new_challenge:
       type: string
+      example: "0x100b6fbe0778ae13e48e9bf71b7de4e31e5c1d73a0b041e0277f4a76b5338604"
       description: The reward chain infusion output, input to next VDF
-    signage_point_index: 
+    signage_point_index:
       type: integer
+      example: 19
       format: uint8
-    sub_epoch_summary_included: 
+    sub_epoch_summary_included:
       type: string
+      example: null
       format: nullable
-    sub_slot_iters: 
+    sub_slot_iters:
       type: integer
+      example: 134217728
       format: uint64
-    timestamp: 
+    timestamp:
       type: integer
+      example: 1616164827
       format: uint64
       nullable: true
-    total_iters: 
+    total_iters:
       type: integer
+      example: 449835673
       format: bigint
       description: Total number of VDF iterations since genesis, including this block
-    weight: 
+    weight:
       type: integer
+      example: 714
       format: bigint
       description: Total cumulative difficulty of all ancestor blocks since genesis

--- a/src/schemas/blockchain_state.yaml
+++ b/src/schemas/blockchain_state.yaml
@@ -1,19 +1,22 @@
 blockchain_state:
   type: object
   description: The node's view of the blockchain.
-  properties: 
+  properties:
     node_id:
       type: string
       format: hex
-    difficulty: 
+    difficulty:
       type: integer
+      example: 3008
       format: uint64
-    genesis_challenge_initialized: 
+    genesis_challenge_initialized:
       type: boolean
-    mempool_size: 
+      example: true
+    mempool_size:
       type: integer
+      example: 0
       format: int32
-    mempool_cost: 
+    mempool_cost:
       type: integer
       format: int32
     mempool_min_fees:
@@ -28,25 +31,31 @@ blockchain_state:
     block_max_cost:
       type: integer
       format: int32
-    peak: 
-      $ref: "./block_record.yaml#/block_record"
+    peak:
+      $ref: ./block_record.yaml#/block_record
       nullable: true
-    space: 
+    space:
       type: integer
+      example: 40110198681182960000
       format: bigint
-    sub_slot_iters: 
+    sub_slot_iters:
       type: integer
+      example: 136314880
       format: uint64
-    sync: 
+    sync:
       type: object
-      properties: 
-        sync_mode: 
+      properties:
+        sync_mode:
           type: boolean
-        sync_progress_height: 
+          example: false
+        sync_progress_height:
           type: integer
+          example: 0
           format: uint64
-        sync_tip_height: 
+        sync_tip_height:
           type: integer
+          example: 0
           format: uint64
-        synced: 
+        synced:
           type: boolean
+          example: false

--- a/src/schemas/cat_info.yaml
+++ b/src/schemas/cat_info.yaml
@@ -4,7 +4,10 @@ cat_info:
   properties:
     asset_id:
       type: string
+      example: a628c1c2c6fcb74d53746157e438e108eab5c0bb3e5c80ff9b1910b3e4832913
     name:
       type: string
+      example: Spacebucks
     symbol:
       type: string
+      example: SBX

--- a/src/schemas/challenge_chain_sub_slot.yaml
+++ b/src/schemas/challenge_chain_sub_slot.yaml
@@ -1,17 +1,21 @@
-﻿challenge_chain_sub_slot:
+challenge_chain_sub_slot:
   type: object
   properties:
     challenge_chain_end_of_slot_vdf:
-      $ref: "./vdf_info.yaml#/vdf_info"
+      $ref: ./vdf_info.yaml#/vdf_info
     infused_challenge_chain_sub_slot_hash:
       type: string
+      example: null
     subepoch_summary_hash:
       type: string
+      example: null
     new_sub_slot_iters:
       type: integer
+      example: null
       format: uint64
       nullable: true
     new_difficulty:
       type: integer
+      example: null
       format: uint64
       nullable: true

--- a/src/schemas/coin.yaml
+++ b/src/schemas/coin.yaml
@@ -1,10 +1,13 @@
-﻿coin:
+coin:
   type: object
   properties:
     parent_coin_info:
       type: string
+      example: "0xccd5bb71183532bff220ba46c268991a00000000000000000000000000004082"
     puzzle_hash:
       type: string
+      example: "0x94c6db00186900418ef7c1f05e127ee1a647cbe6e514ec3bc57acb7bbe6dfb10"
     amount:
       type: integer
+      example: 1750000000000
       format: uint64

--- a/src/schemas/coin_record.yaml
+++ b/src/schemas/coin_record.yaml
@@ -1,18 +1,23 @@
-﻿coin_record:
+coin_record:
   type: object
   properties:
     coin:
-      $ref: "./coin.yaml#/coin"
+      $ref: ./coin.yaml#/coin
     confirmed_block_index:
       type: integer
+      example: 922637
       format: uint32
     spent_block_index:
       type: integer
+      example: 922641
       format: uint32
     spent:
       type: boolean
+      example: true
     coinbase:
       type: boolean
+      example: false
     timestamp:
       type: integer
+      example: 1632832094
       format: uint64

--- a/src/schemas/coin_spend.yaml
+++ b/src/schemas/coin_spend.yaml
@@ -1,9 +1,21 @@
-﻿coin_spend:
+coin_spend:
   type: object
   properties:
     coin:
-      $ref: "./coin.yaml#/coin"
+      $ref: ./coin.yaml#/coin
     puzzle_reveal:
       type: string
+      example: "0xff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1df\
+        f0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff\
+        01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff0\
+        4ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080\
+        ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff0\
+        6ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff80808080\
+        80ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0aec9c2e5984fe92\
+        8406abca942d55ec6b56340af8315bfefa55889dbaade669b9fd3f330af2af44c2a0626\
+        d383e64757ff018080"
     solution:
       type: string
+      example: "0xff80ffff01ffff33ffa03fa549a708302b401c45cf387f8f03b4f76b7c9eabf567b\
+        ea974f61dedf721e0ff840098968080ffff33ffa055b9fe4c9ce0cef8ad574bf5a9158d\
+        c0db7848b96be1a98ab2806d8f0a376a08ff860197738845808080ff8080"

--- a/src/schemas/condition_with_args.yaml
+++ b/src/schemas/condition_with_args.yaml
@@ -1,9 +1,15 @@
-﻿condition_with_args:
+condition_with_args:
   type: object
   properties:
     opcode:
       type: string
+      example: CREATE_COIN
     vars:
       type: array
+      example:
+        - "0x3be9de8637a998987687d6e3f1df95b6bcde6a2cbc7ed96b40fbc9d76bb5033d"
+        - "0x00ec8e78e9"
+        - 0x
       items:
         type: string
+        example: "0x3be9de8637a998987687d6e3f1df95b6bcde6a2cbc7ed96b40fbc9d76bb5033d"

--- a/src/schemas/farmer_rewards.yaml
+++ b/src/schemas/farmer_rewards.yaml
@@ -3,16 +3,21 @@ farmer_rewards:
   properties:
     farmed_amount:
       type: integer
+      example: 0
       format: uint64
     pool_reward_amount:
       type: integer
+      example: 0
       format: uint64
     farmer_reward_amount:
       type: integer
+      example: 0
       format: uint64
     fee_amount:
       type: integer
+      example: 0
       format: uint64
     last_height_farmed:
       type: integer
+      example: 0
       format: uint64

--- a/src/schemas/foliage.yaml
+++ b/src/schemas/foliage.yaml
@@ -1,15 +1,24 @@
-﻿foliage:
+foliage:
   type: object
   properties:
     prev_block_hash:
       type: string
+      example: "0x0b08b0ceca65b371729ad3731ba5982c0c63d487cd526874fb907c3e683eb185"
     reward_block_hash:
       type: string
+      example: "0xcc705bd601b6c9e3081bde85db2a917d312716136e077c37e7f5090c2685733f"
     foliage_block_data:
-      $ref: "./foliage_block_data.yaml#/foliage_block_data"
+      $ref: ./foliage_block_data.yaml#/foliage_block_data
     foliage_block_data_signature:
       type: string
+      example: "0x838f98f281429094df95adbd023f7ac285ffe08d7e584e0e1c9d6def26b215f8675\
+        3f52d781116eab02ac949beea9b9c009b6242ba97568f226aeafc2bf4fc83b791fffb2d\
+        636a8b0473727b5bee6a560b09df3dabf9d2b4ca707a35f22e5f38"
     foliage_transaction_block_hash:
       type: string
+      example: "0x813540921a72fdfcbe47858e087b9e848df5fe2d8213288a6df71acf22214cf2"
     foliage_transaction_block_signature:
       type: string
+      example: "0xb0db31ae6d773b3b27009cfdd9a232b54f840e00caf24a5a87e8c27e96933acd03d\
+        8e553ea62e9179ed4078ed86b9e471987e8803ff4311c9d0727d876490012af403094e3\
+        baa4f627785d846c60f770494c253ea7a09e7bc24a53ad683e4704"

--- a/src/schemas/foliage_block_data.yaml
+++ b/src/schemas/foliage_block_data.yaml
@@ -1,13 +1,19 @@
-﻿foliage_block_data:
+foliage_block_data:
   type: object
   properties:
     unfinished_reward_block_hash:
       type: string
+      example: "0xcc705bd601b6c9e3081bde85db2a917d312716136e077c37e7f5090c2685733f"
     pool_target:
-      $ref: "./pool_target.yaml#/pool_target"
+      $ref: ./pool_target.yaml#/pool_target
     pool_signature:
       type: string
+      example: "0xb39237cb5db187f1a3f210f5fff1bee0f7b66e466eb1bd393204768d982335f3ee5\
+        c7faec138e334110d80ce47e46704067db26f8a2c5267bbaefb74ea9ef144bd51a8fe38\
+        8ba68727f3e246b8aefef427b2e2e299ed976d27ba2789bcf7cb7c"
     farmer_reward_puzzle_hash:
       type: string
+      example: "0x77c08f1ae7c6ae4808c8c07f7d99363b0c00f0ad416c4a292b5341282e38dc35"
     extension_data:
       type: string
+      example: "0x0000000000000000000000000000000000000000000000000000000003a2c7c9"

--- a/src/schemas/foliage_transaction_block.yaml
+++ b/src/schemas/foliage_transaction_block.yaml
@@ -1,16 +1,22 @@
-﻿foliage_transaction_block:
+foliage_transaction_block:
   type: object
   properties:
     prev_transaction_block_hash:
       type: string
+      example: "0xf88a87d79c8e65ca559b7e74a9aca3a6f9fc90e6bb9dc6cb4602ed599610876e"
     timestamp:
       type: integer
+      example: 1636577488
       format: uint64
     filter_hash:
       type: string
+      example: "0xea0d50f296d1bdaccc00be16e48a310dd4fa1fcf575065761add6366498b3fbf"
     additions_root:
       type: string
+      example: "0x2c04ae163cf5916b774e2591b075560b6dface2b242d10cbb9f40b134cdf2080"
     removals_root:
       type: string
+      example: "0x409433654e3b7a530da6cf55c93abde2c7a71a2ea9814883ceef956f8fed61ea"
     transactions_info_hash:
       type: string
+      example: "0x9f3d9cb990c560fb66d4e09a9da79844ce933a809bc754eb151775f3600b73ed"

--- a/src/schemas/full_block.yaml
+++ b/src/schemas/full_block.yaml
@@ -1,32 +1,35 @@
-﻿full_block:
+full_block:
   type: object
   properties:
     finished_sub_slots:
       type: array
+      example: []
       items:
-        $ref: "./end_of_sub_slot_bundle.yaml#/end_of_sub_slot_bundle"
+        $ref: ./end_of_sub_slot_bundle.yaml#/end_of_sub_slot_bundle
     reward_chain_block:
-      $ref: "./reward_chain_block.yaml#/reward_chain_block"
+      $ref: ./reward_chain_block.yaml#/reward_chain_block
     challenge_chain_sp_proof:
-      $ref: "./vdf_proof.yaml#/vdf_proof"
+      $ref: ./vdf_proof.yaml#/vdf_proof
     challenge_chain_ip_proof:
-      $ref: "./vdf_proof.yaml#/vdf_proof"
+      $ref: ./vdf_proof.yaml#/vdf_proof
     reward_chain_sp_proof:
-      $ref: "./vdf_proof.yaml#/vdf_proof"
+      $ref: ./vdf_proof.yaml#/vdf_proof
     reward_chain_ip_proof:
-      $ref: "./vdf_proof.yaml#/vdf_proof"
+      $ref: ./vdf_proof.yaml#/vdf_proof
     infused_challenge_chain_ip_proof:
-      $ref: "./vdf_proof.yaml#/vdf_proof"
+      $ref: ./vdf_proof.yaml#/vdf_proof
     foliage:
-      $ref: "./foliage.yaml#/foliage"
+      $ref: ./foliage.yaml#/foliage
     foliage_transaction_block:
-      $ref: "./foliage_transaction_block.yaml#/foliage_transaction_block"
+      $ref: ./foliage_transaction_block.yaml#/foliage_transaction_block
     transactions_info:
-      $ref: "./transactions_info.yaml#/transactions_info"
+      $ref: ./transactions_info.yaml#/transactions_info
     transactions_generator:
       type: string
+      example: null
     transactions_generator_ref_list:
       type: array
+      example: []
       items:
         type: integer
         format: uint32

--- a/src/schemas/layer.yaml
+++ b/src/schemas/layer.yaml
@@ -1,14 +1,17 @@
-﻿layer:
+layer:
   type: object
   properties:
     other_hash_side:
       type: string
+      example: left
       format: bytes32
     other_hash:
       type: string
+      example: cd4046b6c3b03e20afd506b50e552f1b698283d72566732134437fcb364c47a5
       format: bytes32
     combined_hash:
       type: string
+      example: 0a3024099e40c27cfe294ce91bdabf727887fecd406d7208c53297f79d4e8902
       format: bytes32
       items:
-        $ref: "./key_value.yaml#/key_value"
+        $ref: ./key_value.yaml#/key_value

--- a/src/schemas/lineage_proof.yaml
+++ b/src/schemas/lineage_proof.yaml
@@ -1,12 +1,15 @@
-﻿lineage_proof:
+lineage_proof:
   type: object
   properties:
     parent_name:
       type: string
+      example: "0xc2347b264b412bde5893f4e1369adab3a6c61496845c10f8ec98bc35f9e1429f"
       format: bytes32
     inner_puzzle_hash:
       type: string
+      example: "0x60f66f9824d5f96d4025b70b4f7ac3def458cae742fbd2d70343eeeaa5a59c58"
       format: bytes32
     amount:
       type: integer
+      example: 1
       format: uint64

--- a/src/schemas/mempool_item.yaml
+++ b/src/schemas/mempool_item.yaml
@@ -1,25 +1,49 @@
-﻿mempool_item:
+mempool_item:
   type: object
   properties:
     spend_bundle:
-      $ref: "./spend_bundle.yaml#/spend_bundle"
+      $ref: ./spend_bundle.yaml#/spend_bundle
     fee:
       type: integer
+      example: 0
       format: uint64
-    n_p_c_result:
-      $ref: "./npc_result.yaml#/npc_result"
+    npc_result:
+      $ref: ./npc_result.yaml#/npc_result
     cost:
       type: integer
+      example: 10940866
       format: uint64
     spend_budndle_name:
       type: string
     additions:
       type: array
+      example:
+        - amount: 3968760041
+          parent_coin_info: "0xbf71e1d17630e3793321944b5825b5b573ac28c03113498baae997e0781f0278"
+          puzzle_hash: "0x3be9de8637a998987687d6e3f1df95b6bcde6a2cbc7ed96b40fbc9d76bb5033d"
       items:
-        $ref: "./coin.yaml#/coin"
+        $ref: ./coin.yaml#/coin
     removals:
       type: array
+      example:
+        - amount: 3981342052
+          parent_coin_info: "0x0252418f0ad7a0009dc055a48a2aaff897f4ea6289b57f1ed9c0d8c7a5b5e6a8"
+          puzzle_hash: "0xdd259fada9e1fbfb1499df0755462222f31ec512404842b5c7dac26b9a5cb29a"
       items:
-        $ref: "./coin.yaml#/coin"
+        $ref: ./coin.yaml#/coin
     program:
       type: string
+      example: "0xff01ffffffa00252418f0ad7a0009dc055a48a2aaff897f4ea6289b57f1ed9c0d8c\
+        7a5b5e6a8ffff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05\
+        ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808\
+        080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff\
+        05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2\
+        f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ff\
+        ff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8\
+        080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0b44f24f7\
+        dae4af24334870c3f291c8a8e4d370fb935f0c30b6d1fee734c229d351fed2a5a87c059\
+        049d205a8ec3c8124ff018080ff8500ed4e7564ffff80ffff01ffff33ffa057b09fa466\
+        e876fed06a697b0b82e237ad81424fa809df8c7f41fbcfcc7fcc25ff8400bffc7b80fff\
+        f33ffa03be9de8637a998987687d6e3f1df95b6bcde6a2cbc7ed96b40fbc9d76bb5033d\
+        ff8500ec8e78e980ffff3cffa029505509405ab0d47b986bb2456c288dc272b7fecad9a\
+        54943db25c26dc03de48080ff8080808080"

--- a/src/schemas/mirror.yaml
+++ b/src/schemas/mirror.yaml
@@ -3,17 +3,25 @@ mirror:
   properties:
     coin_id:
       type: string
+      example: b5756487c17fe3a2628e45a9d3d42e89231af718bb1735e6c8441e07ec005f9d
       format: bytes32
     launcher_id:
       type: string
+      example: 1a119374fc7d7055d3419fdcd7f93065f28a1e4acacdf9c73b933b27b685550f
       format: bytes32
     amount:
       type: integer
+      example: 1000
       format: uint64
     urls:
       type: array
+      example:
+        - http://www.example.com:8575
+        - http://www.example2.com:8575
       items:
         type: string
+        example: http://www.example.com:8575
         format: bytes32
     ours:
       type: boolean
+      example: true

--- a/src/schemas/mnemonic.yaml
+++ b/src/schemas/mnemonic.yaml
@@ -1,7 +1,33 @@
 mnemonic:
   description: 24 words of entropy.
   type: array
+  example:
+    - hint
+    - dice
+    - session
+    - fun
+    - budget
+    - strong
+    - album
+    - lava
+    - tackle
+    - sudden
+    - garage
+    - people
+    - bundle
+    - federal
+    - chest
+    - process
+    - vicious
+    - behave
+    - nephew
+    - zero
+    - vital
+    - ocean
+    - artist
+    - lawsuit
   items:
     type: string
+    example: hint
   minItems: 24
   maxItems: 24

--- a/src/schemas/network_info.yaml
+++ b/src/schemas/network_info.yaml
@@ -6,6 +6,8 @@ network_info:
     - network_prefix
   properties:
     network_name:
-      type: "string"
+      type: string
+      example: mainnet
     network_prefix:
-      type: "string"
+      type: string
+      example: xch

--- a/src/schemas/nft_info.yaml
+++ b/src/schemas/nft_info.yaml
@@ -4,41 +4,60 @@ nft_info:
   properties:
     launcher_id:
       type: string
+      example: "0x821fdd13fe209466f1c69d82eb951cf630d28e901c2e14285d8a574dbde034c4"
       format: hex
     nft_coin_id:
       type: string
+      example: "0x9bcf429079bd8e394658a3f0c43c6641c9f92d0dcc1770eeb6be6588a49fc925"
       format: hex
     owner_did:
       type: string
+      example: "0xd590645dc77e25f22ffe37846e73868a99179d33de11648efaa286bc341936ea"
     royalty_percentage:
       type: integer
+      example: 300
       format: uint16
     royalty_puzzle_hash:
       type: string
+      example: "0x0fe4e859760b755980c9a92c91459b75eb4f02135ace8d2731eca0e89ceef1fb"
       format: hex
     data_uris:
       type: array
+      example:
+        - https://images.pexels.com/photos/11053072/pexels-photo-11053072.jpeg
       items:
         type: string
+        example: https://images.pexels.com/photos/11053072/pexels-photo-11053072.jpeg
         format: uri
     data_hash:
       type: string
+      example: "0x14836b86a48e1b2b5e857213af97534704475b4c155d34b2cb83ed4b7cba2bb0"
       format: hex
     metadata_uris:
       type: array
+      example:
+        - https://metadata_example.com
+        - https://metadata_example2.com
       items:
         type: string
+        example: https://metadata_example.com
         format: uri
     metadata_hash:
       type: string
+      example: "0x868463c2ae6f8a9585156c9ad9f4b9b01eeacc56fec82aa629c97135ff21823e"
       format: hex
     license_uris:
       type: array
+      example:
+        - https://license_example.com
+        - https://license_example2.com
       items:
         type: string
+        example: https://license_example.com
         format: uri
     license_hash:
       type: string
+      example: "0x358d4eb4aedefbec22824036299eff24216d213a95c8f986f862f0a89a250a82"
       format: hex
     series_total:
       type: integer
@@ -48,17 +67,32 @@ nft_info:
       format: uint64
     updater_puzhash:
       type: string
+      example: "0xfe8a4b4e27a2e29a4d3fc7ce9d527adbcaccbab6ada3903ccf3ba9a769d2d78b"
       format: hex
     chain_info:
       type: string
+      example: ((117
+        "https://images.pexels.com/photos/11053072/pexels-photo-11053072.jpeg")
+        (104 .
+        0x14836b86a48e1b2b5e857213af97534704475b4c155d34b2cb83ed4b7cba2bb0)
+        (28021 "https://metadata_example.com", "https://metadata_example2.com")
+        (27765 "https://license_example.com", "https://license_example2.com")
+        (29550 . 1) (29556 . 5) (28008 .
+        0x868463c2ae6f8a9585156c9ad9f4b9b01eeacc56fec82aa629c97135ff21823e)
+        (27752 .
+        0x358d4eb4aedefbec22824036299eff24216d213a95c8f986f862f0a89a250a82))
     mint_height:
       type: integer
+      example: 1127304
       format: uint32
     supports_did:
       type: boolean
+      example: true
     pending_transaction:
       type: boolean
+      example: false
       default: false
     launcher_puzhash:
       type: string
+      example: "0xeff07522495060c066f66f32acc2a77e3a3e737aca8baea4d1a64ea4cdc13da9"
       format: hex

--- a/src/schemas/npc.yaml
+++ b/src/schemas/npc.yaml
@@ -1,11 +1,28 @@
-﻿npc:
+npc:
   type: object
   properties:
     coin_name:
       type: string
+      example: "0xbf71e1d17630e3793321944b5825b5b573ac28c03113498baae997e0781f0278"
     puzzle_hash:
       type: string
+      example: "0xdd259fada9e1fbfb1499df0755462222f31ec512404842b5c7dac26b9a5cb29a"
     conditions:
       type: array
+      example:
+        - - "0x33"
+          - - opcode: CREATE_COIN
+              vars:
+                - "0x3be9de8637a998987687d6e3f1df95b6bcde6a2cbc7ed96b40fbc9d76b\
+                  b5033d"
+                - "0x00ec8e78e9"
+                - 0x
+        - - "0x32"
+          - - opcode: AGG_SIG_ME
+              vars:
+                - "0xb44f24f7dae4af24334870c3f291c8a8e4d370fb935f0c30b6d1fee734\
+                  c229d351fed2a5a87c059049d205a8ec3c8124"
+                - "0xcae8db944550d51ef9eb4bdc297ac7a2ddb759f2e202c13df629abb41c\
+                  c69290"
       items:
-        $ref: "./condition.yaml#/condition"
+        $ref: ./condition.yaml#/condition

--- a/src/schemas/npc_result.yaml
+++ b/src/schemas/npc_result.yaml
@@ -1,14 +1,34 @@
-﻿npc_result:
+npc_result:
   type: object
   properties:
     error:
       type: integer
+      example: null
       format: uint16
       nullable: true
     npc_list:
       type: array
+      example:
+        - coin_name: "0xbf71e1d17630e3793321944b5825b5b573ac28c03113498baae997e0781f0278"
+          conditions:
+            - - "0x33"
+              - - opcode: CREATE_COIN
+                  vars:
+                    - "0x3be9de8637a998987687d6e3f1df95b6bcde6a2cbc7ed96b40fbc9\
+                      d76bb5033d"
+                    - "0x00ec8e78e9"
+                    - 0x
+            - - "0x32"
+              - - opcode: AGG_SIG_ME
+                  vars:
+                    - "0xb44f24f7dae4af24334870c3f291c8a8e4d370fb935f0c30b6d1fe\
+                      e734c229d351fed2a5a87c059049d205a8ec3c8124"
+                    - "0xcae8db944550d51ef9eb4bdc297ac7a2ddb759f2e202c13df629ab\
+                      b41cc69290"
+          puzzle_hash: "0xdd259fada9e1fbfb1499df0755462222f31ec512404842b5c7dac26b9a5cb29a"
       items:
-        $ref: "./npc.yaml#/npc"
+        $ref: ./npc.yaml#/npc
     clvm_cost:
       type: integer
+      example: 416866
       format: uint64

--- a/src/schemas/offer_store.yaml
+++ b/src/schemas/offer_store.yaml
@@ -3,8 +3,12 @@ offer_store:
   properties:
     store_id:
       type: string
+      example: 14d1c3042ef38d76796146e6248e02b73db7a0eeefb740fa2e8439dad15bca27
       format: bytes32
     inclusions:
       type: array
+      example:
+        - key: "9999"
+          value: abc123
       items:
-        $ref: "./key_value.yaml#/key_value"
+        $ref: ./key_value.yaml#/key_value

--- a/src/schemas/pool_target.yaml
+++ b/src/schemas/pool_target.yaml
@@ -1,8 +1,10 @@
-﻿pool_target:
+pool_target:
   type: object
   properties:
     puzzle_hash:
       type: string
+      example: "0x77c08f1ae7c6ae4808c8c07f7d99363b0c00f0ad416c4a292b5341282e38dc35"
     max_height:
       type: integer
+      example: 0
       format: uint32

--- a/src/schemas/private_key.yaml
+++ b/src/schemas/private_key.yaml
@@ -3,18 +3,26 @@ private_key:
   properties:
     fingerprint:
       type: integer
+      example: 2473794447
       format: uint32
     sk:
       type: string
+      example: 0665913196501420c0fe2de6b5ce7b25f749d52dcbf997b069bb2ea8438c6c3c
       format: hex
-    pk: 
+    pk:
       type: string
+      example: b73cf2471b10a7ba839616aff0ab1cb319d9d3a77ee26ff88ec1c8e645468eb0b7653518b85e5dd0df7cf50d8612b978
       format: hex
-    farmer_pk: 
+    farmer_pk:
       type: string
+      example: 8c65856685323f149a651e6cbe068ece36f87a84efa16246b0eef65ac586a30fb678878bd4364d52c432fbb77838cbf6
       format: hex
-    pool_pk: 
+    pool_pk:
       type: string
+      example: 845ff087376ffecf83950485d63ffed1cc73f36daf018deb4fbd2f05e7198b07521486274d82ecc4f5a2eaae63dfd0a7
       format: hex
-    seed: 
+    seed:
       type: string
+      example: arrest legend bounce attend rebel blade palace bean dry shell nice
+        bubble coil cook token nerve visa december hero garment grid attend
+        nerve certain

--- a/src/schemas/proof.yaml
+++ b/src/schemas/proof.yaml
@@ -1,16 +1,26 @@
-﻿proof:
+proof:
   type: object
   properties:
     key:
       type: string
+      example: "9999"
       format: bytes32
     value:
       type: string
+      example: abc123
       format: bytes32
     node_hash:
       type: string
+      example: b87c24e0521f559236a2e06d6e1bb196c138c1c9bfcadad3b25708e7eab97ca7
       format: bytes32
     layers:
       type: array
+      example:
+        - combined_hash: 0a3024099e40c27cfe294ce91bdabf727887fecd406d7208c53297f79d4e8902
+          other_hash: cd4046b6c3b03e20afd506b50e552f1b698283d72566732134437fcb364c47a5
+          other_hash_side: left
+        - combined_hash: 568ca0020114772138db61001c63ac8574a7c8c76c051dd2d3e28964496aa88c
+          other_hash: 919735911d7f9ca0de316878ddb92e7772c9f39bf9d37e9d84ccab39f5d49a11
+          other_hash_side: left
       items:
-        $ref: "./layer.yaml#/layer"
+        $ref: ./layer.yaml#/layer

--- a/src/schemas/proof_of_space.yaml
+++ b/src/schemas/proof_of_space.yaml
@@ -1,15 +1,27 @@
-﻿proof_of_space:
+proof_of_space:
   type: object
   properties:
     challenge:
       type: string
+      example: "0xad43c12b5c5a480ee93992697bd8c9153d536007b0ffac024341cd8ca853a9e3"
     public_pool_key:
       type: string
     pool_contract_puzzle_hash:
       type: string
+      example: "0x71afdce401a0f2a6f03de6287902eacfa38502d6667b04da36e32c3930171ce4"
     plot_public_key:
       type: string
+      example: "0x8b5f3cd22bf5073e12f285d2a0e9bbfb485fea8f3ede2f5573e44168fadbb91b71c\
+        ef1dffc03758a5241c47b105df81a"
     size:
-      $ref: "../schemas/k_size.yaml#/k_size"
+      $ref: ../schemas/k_size.yaml#/k_size
     proof:
       type: string
+      example: "0xa84606d3dba86cbc1c2f56d05175bbbcb970629380bec5c49ad46f0c5f067e4ba74\
+        101ac24f0e09fb73ce0ebc9249436c528b5fab689d94c4213072e2acfc1c3a6f17763b1\
+        6304234002ce471da4ce7e888e2f5abadf4d7f48cd157294ce03cb28df0f45597ca5460\
+        cd66c772c7650f2d170d08a5898fe65623b33aac864f44d2a39bcf074e62866edccf9b4\
+        24f9a8ca56c9a98e87d48fb02b933af951284d610ff1eb71e730a05c2f6c7be86fd4df7\
+        efb26e8fb2e573981d8ad866adc02a82ffb0d7ff106c9c78f9cea08f4a2de9db2607266\
+        edf6e807924edf9af0f36b8938d97865072126011b67646b4d0e206b706d3a3e67e8862\
+        cb0502520f1ad1b4341"

--- a/src/schemas/reward_chain_block.yaml
+++ b/src/schemas/reward_chain_block.yaml
@@ -1,4 +1,4 @@
-﻿reward_chain_block:
+reward_chain_block:
   type: object
   properties:
     weight:
@@ -9,27 +9,36 @@
       format: uint32
     total_iters:
       type: integer
+      example: 4212156346430
       format: bigint
     signage_point_index:
       type: integer
+      example: 37
       format: uint8
     pos_ss_cc_challenge_hash:
       type: string
+      example: "0x04b130f89a8fc37519eab0d835a43ef5547552b2b67c5129fa00f79a57ba8d7f"
     proof_of_space:
-      $ref: "./proof_of_space.yaml#/proof_of_space"
+      $ref: ./proof_of_space.yaml#/proof_of_space
     challenge_chain_sp_vdf:
-      $ref: "./vdf_info.yaml#/vdf_info"
+      $ref: ./vdf_info.yaml#/vdf_info
     challenge_chain_sp_signature:
       type: string
+      example: "0xa6058eaa6e9cf8469e152e80b4ac4c3cfdca8660cbe44ca50d3771ab1bbf1d040cb\
+        a842d1b9bf633756159859ecb2ebc05b5f994cef91d5915d4763284e340095a59fb87f2\
+        e50fc3f0b6658d1663aeb9d6732373203d7e45df56eb19baeff64c"
     challenge_chain_ip_vdf:
-      $ref: "./vdf_info.yaml#/vdf_info"
+      $ref: ./vdf_info.yaml#/vdf_info
     reward_chain_sp_vdf:
-      $ref: "./vdf_info.yaml#/vdf_info"
+      $ref: ./vdf_info.yaml#/vdf_info
     reward_chain_sp_signature:
       type: string
+      example: "0xa4fb8eb7afc74b945efe1f6b28453a708df7de1f0b56239c5fed50974b896b9bb1f\
+        559b49b5a6cf7f4351f1545918b5017e28e81f974bc7bdba88b61f2f9ca8492ab9b7d23\
+        371e579b30da9a1a5c7dc0a8fe5605a86165d34c3c552f509fdd7b"
     reward_chain_ip_vdf:
-      $ref: "./vdf_info.yaml#/vdf_info"
+      $ref: ./vdf_info.yaml#/vdf_info
     infused_challenge_chain_ip_vdf:
-      $ref: "./vdf_info.yaml#/vdf_info"
+      $ref: ./vdf_info.yaml#/vdf_info
     is_transaction_block:
       type: boolean

--- a/src/schemas/reward_chain_block_unfinished.yaml
+++ b/src/schemas/reward_chain_block_unfinished.yaml
@@ -1,21 +1,30 @@
-﻿reward_chain_block_unfinished:
+reward_chain_block_unfinished:
   type: object
   properties:
     total_iters:
       type: integer
+      example: 4212156346430
       format: bigint
     signage_point_index:
       type: integer
+      example: 37
       format: uint8
     pos_ss_cc_challenge_hash:
       type: string
+      example: "0x04b130f89a8fc37519eab0d835a43ef5547552b2b67c5129fa00f79a57ba8d7f"
     proof_of_space:
-      $ref: "./proof_of_space.yaml#/proof_of_space"
+      $ref: ./proof_of_space.yaml#/proof_of_space
     challenge_chain_sp_vdf:
-      $ref: "./vdf_info.yaml#/vdf_info"
+      $ref: ./vdf_info.yaml#/vdf_info
     challenge_chain_sp_signature:
       type: string
+      example: "0xa6058eaa6e9cf8469e152e80b4ac4c3cfdca8660cbe44ca50d3771ab1bbf1d040cb\
+        a842d1b9bf633756159859ecb2ebc05b5f994cef91d5915d4763284e340095a59fb87f2\
+        e50fc3f0b6658d1663aeb9d6732373203d7e45df56eb19baeff64c"
     reward_chain_sp_vdf:
-      $ref: "./vdf_info.yaml#/vdf_info"
+      $ref: ./vdf_info.yaml#/vdf_info
     reward_chain_sp_signature:
       type: string
+      example: "0xa4fb8eb7afc74b945efe1f6b28453a708df7de1f0b56239c5fed50974b896b9bb1f\
+        559b49b5a6cf7f4351f1545918b5017e28e81f974bc7bdba88b61f2f9ca8492ab9b7d23\
+        371e579b30da9a1a5c7dc0a8fe5605a86165d34c3c552f509fdd7b"

--- a/src/schemas/reward_chain_sub_slot.yaml
+++ b/src/schemas/reward_chain_sub_slot.yaml
@@ -1,12 +1,15 @@
-﻿reward_chain_sub_slot:
+reward_chain_sub_slot:
   type: object
   properties:
     end_of_slot_vdf:
-      $ref: "./vdf_info.yaml#/vdf_info"
+      $ref: ./vdf_info.yaml#/vdf_info
     challenge_chain_sub_slot_hash:
       type: string
+      example: "0xe44e06ed13eb06c7c2f0218945b7c62e785d6482c27ebbe69aab499ae199258c"
     infused_challenge_chain_sub_slot_hash:
       type: string
+      example: null
     deficit:
       type: integer
+      example: 12
       format: uint8

--- a/src/schemas/singleton_record.yaml
+++ b/src/schemas/singleton_record.yaml
@@ -1,28 +1,36 @@
-﻿singleton_record:
+singleton_record:
   type: object
   properties:
     coin_id:
       type: string
+      example: "0x70e75ede3b9ba91ab4b91bc5efea8946fde60518becdce40e2cf6800ff173245"
       format: bytes32
     launcher_id:
       type: string
+      example: "0x4aecd65d5fd0dcac59ef41ad5a74134e38b3e8334aebb1356972b7e9c793a09e"
       format: bytes32
     root:
       type: string
+      example: "0x0000000000000000000000000000000000000000000000000000000000000000"
       format: bytes32
     inner_puzzle_hash:
       type: string
+      example: "0x607b04952b317c81eb21ba96ff5f62adb58621f89d5fe6240f6e83d4395998c5"
       format: bytes32
     confirmed:
       type: boolean
+      example: true
     confirmed_at_height:
       type: integer
+      example: 2872567
       format: uint32
     lineage_proof:
-      $ref: "./lineage_proof.yaml#/lineage_proof"
+      $ref: ./lineage_proof.yaml#/lineage_proof
     generation:
       type: integer
+      example: 1
       format: uint32
     timestamp:
       type: integer
+      example: 1669352585
       format: uint64

--- a/src/schemas/spend_bundle.yaml
+++ b/src/schemas/spend_bundle.yaml
@@ -1,9 +1,31 @@
-﻿spend_bundle:
+spend_bundle:
   type: object
   properties:
     aggregated_signature:
       type: string
+      example: "0xa5e5ea1f5ae2335a72fe0a7ed7ca39e8f142e2e1f6e37a348482290e88eb9cea2d9\
+        73acf6145e34d0afeee7ba22f99850641e21a549b2c092bb49aa393acd938825bccca94\
+        13c1a268ba44367bc8433cd0fc0eb82e87bebe23817aa695bdb566"
     coin_spends:
       type: array
+      example:
+        - coin:
+            amount: 1750000000000
+            parent_coin_info: "0xccd5bb71183532bff220ba46c268991a00000000000000000000000000\
+              004082"
+            puzzle_hash: "0x94c6db00186900418ef7c1f05e127ee1a647cbe6e514ec3bc57acb7bbe6dfb1\
+              0"
+          puzzle_reveal: "0xff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05f\
+            fff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080\
+            808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04f\
+            fff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ff\
+            ff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff0\
+            1ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff\
+            04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff01808\
+            0ffff04ffff01b0aec9c2e5984fe928406abca942d55ec6b56340af8315bfefa558\
+            89dbaade669b9fd3f330af2af44c2a0626d383e64757ff018080"
+          solution: "0xff80ffff01ffff33ffa03fa549a708302b401c45cf387f8f03b4f76b7c9eabf567\
+            bea974f61dedf721e0ff840098968080ffff33ffa055b9fe4c9ce0cef8ad574bf5a\
+            9158dc0db7848b96be1a98ab2806d8f0a376a08ff860197738845808080ff8080"
       items:
-        $ref: "./coin_spend.yaml#/coin_spend"
+        $ref: ./coin_spend.yaml#/coin_spend

--- a/src/schemas/store_proofs.yaml
+++ b/src/schemas/store_proofs.yaml
@@ -1,10 +1,22 @@
-﻿store_proofs:
+store_proofs:
   type: object
   properties:
     store_id:
       type: string
+      example: 14d1c3042ef38d76796146e6248e02b73db7a0eeefb740fa2e8439dad15bca27
       format: bytes32
     proofs:
       type: array
+      example:
+        - key: "9999"
+          layers:
+            - combined_hash: 0a3024099e40c27cfe294ce91bdabf727887fecd406d7208c53297f79d4e8902
+              other_hash: cd4046b6c3b03e20afd506b50e552f1b698283d72566732134437fcb364c47a5
+              other_hash_side: left
+            - combined_hash: 568ca0020114772138db61001c63ac8574a7c8c76c051dd2d3e28964496aa88c
+              other_hash: 919735911d7f9ca0de316878ddb92e7772c9f39bf9d37e9d84ccab39f5d49a11
+              other_hash_side: left
+          node_hash: b87c24e0521f559236a2e06d6e1bb196c138c1c9bfcadad3b25708e7eab97ca7
+          value: abc123
       items:
-        $ref: "./proof.yaml#/proof"
+        $ref: ./proof.yaml#/proof

--- a/src/schemas/sub_slot_proofs.yaml
+++ b/src/schemas/sub_slot_proofs.yaml
@@ -1,9 +1,9 @@
-﻿sub_slot_proofs:
+sub_slot_proofs:
   type: object
   properties:
     challenge_chain_slot_proof:
-      $ref: "./vdf_proof.yaml#/vdf_proof"
+      $ref: ./vdf_proof.yaml#/vdf_proof
     infused_challenge_chain_slot_proof:
-      $ref: "./vdf_proof.yaml#/vdf_proof"
+      $ref: ./vdf_proof.yaml#/vdf_proof
     reward_chain_slot_proof:
-      $ref: "./vdf_proof.yaml#/vdf_proof"
+      $ref: ./vdf_proof.yaml#/vdf_proof

--- a/src/schemas/trade_record.yaml
+++ b/src/schemas/trade_record.yaml
@@ -7,35 +7,45 @@ trade_record:
       format: uint32
     accepted_at_time:
       type: integer
+      example: null
       format: uint64
       nullable: true
     created_at_time:
       type: integer
+      example: 1669275137
       format: uint64
     is_my_offer:
       type: boolean
+      example: true
     sent:
       type: integer
+      example: 0
       format: uint32
     offer:
       type: string
     taken_offer:
       type: string
+      example: null
     coins_of_interest:
       type: array
+      example:
+        - amount: 999999
+          parent_coin_info: "0x60a8b06515aaefe74236eb234130d769a1b65c99706414901277926fe29c3360"
+          puzzle_hash: "0xad5de77c7da1316b9b72708d17dbb8937855d740ebaf85669b8bd925275e8d49"
       items:
-        $ref: "./coin.yaml#/coin"
+        $ref: ./coin.yaml#/coin
     trade_id:
       type: string
+      example: "0x84d14398c1a38f376953bf8fa76cbee0d3216b382266d38b5612f17e96bcd1de"
       format: hex
     status:
-      $ref: "./trade_status.yaml#/trade_status"
+      $ref: ./trade_status.yaml#/trade_status
     sent_to:
       type: array
-      description:
-        Represents the list of peers that we sent the transaction to, whether each one
-        included it in the mempool, and what the error message (if any) was.
-        List[Tuple[str, uint8, Optional[str]]]
+      example: []
+      description: Represents the list of peers that we sent the transaction to,
+        whether each one included it in the mempool, and what the error message
+        (if any) was. List[Tuple[str, uint8, Optional[str]]]
       items:
         type: array
         items:

--- a/src/schemas/transaction_record.yaml
+++ b/src/schemas/transaction_record.yaml
@@ -4,43 +4,59 @@ transaction_record:
   properties:
     confirmed_at_height:
       type: integer
+      example: 2863494
       format: uint32
     created_at_time:
       type: integer
+      example: 1669182237
       format: uint64
     to_puzzle_hash:
       type: string
+      example: "0xb6ed191a2f80194f49fe33e9b9254642ca942ee287faeca2a45f4b96a5c0875a"
       format: hex
     amount:
       type: integer
+      example: 100
       format: uint64
     fee_amount:
       type: integer
+      example: 0
       format: uint64
     confirmed:
       type: boolean
+      example: true
     sent:
       type: integer
+      example: 10
       format: uint32
     spend_bundle:
-      $ref: "./spend_bundle.yaml#/spend_bundle"
+      $ref: ./spend_bundle.yaml#/spend_bundle
     additions:
       type: array
+      example:
+        - amount: 100
+          parent_coin_info: "0xabbb6c6859db74e8e627f21263c078893383131bcf22faec68b2de914d03e59f"
+          puzzle_hash: "0xb4a41bbce457745b006181ab99e34a0cbd8c83c196bc74fc98eb3aec882ed784"
       items:
-        $ref: "./coin.yaml#/coin"
+        $ref: ./coin.yaml#/coin
     removals:
       type: array
+      example:
+        - amount: 100
+          parent_coin_info: "0x9c0083d8da8733c899787e4dcf18a56bc944f49ed668808e20890f01cbc35f37"
+          puzzle_hash: "0xb4a41bbce457745b006181ab99e34a0cbd8c83c196bc74fc98eb3aec882ed784"
       items:
-        $ref: "./coin.yaml#/coin"
+        $ref: ./coin.yaml#/coin
     wallet_id:
       type: integer
+      example: 2
       format: uint32
     sent_to:
       type: array
-      description:
-        Represents the list of peers that we sent the transaction to, whether each one
-        included it in the mempool, and what the error message (if any) was.
-        List[Tuple[str, uint8, Optional[str]]]
+      example: []
+      description: Represents the list of peers that we sent the transaction to,
+        whether each one included it in the mempool, and what the error message
+        (if any) was. List[Tuple[str, uint8, Optional[str]]]
       items:
         type: array
         items:
@@ -52,14 +68,17 @@ transaction_record:
             - type: string
     trade_id:
       type: string
+      example: null
       format: hex
     type:
-      $ref: "./transaction_type.yaml#/transaction_type"
+      $ref: ./transaction_type.yaml#/transaction_type
     name:
       type: string
+      example: "0x43f6811a4daf18622fc7f132f5166a1246056b4a983b7befccb7e4b2e2c57f3b"
       format: hex
     memos:
       type: array
+      example: {}
       description: List[Tuple[bytes32, List[bytes]]]
       items:
         type: object

--- a/src/schemas/vdf_info.yaml
+++ b/src/schemas/vdf_info.yaml
@@ -1,11 +1,13 @@
-﻿vdf_info:
+vdf_info:
   type: object
   description: Used to generate the discriminant (VDF group)
   properties:
     challenge:
       type: string
+      example: "0xeb8c4d20b322be8d9fddbf9412016bdffe9a2901d7edb0e364e94266d0e095f7"
     number_of_iterations:
       type: integer
+      example: 1024
       format: uint64
     output:
-      $ref: "./classgroup_element.yaml#/classgroup_element"
+      $ref: ./classgroup_element.yaml#/classgroup_element

--- a/src/schemas/vdf_proof.yaml
+++ b/src/schemas/vdf_proof.yaml
@@ -1,10 +1,15 @@
-﻿vdf_proof:
+vdf_proof:
   type: object
   properties:
     witness_type:
       type: integer
+      example: 0
       format: uint8
     witness:
       type: string
+      example: "0x02004c0001010000000000000000000000000000000000000000000000000000000\
+        00000000000000000000000000000000000000000000000000000000000000000000000\
+        00000000000000000000000000000000000000000000000000000000000000"
     normalized_to_identity:
       type: boolean
+      example: false

--- a/src/schemas/wallet_balance.yaml
+++ b/src/schemas/wallet_balance.yaml
@@ -3,26 +3,33 @@ wallet_balance:
   properties:
     confirmed_wallet_balance:
       type: integer
+      example: 999999799
       format: uint64
     unconfirmed_wallet_balance:
       type: integer
+      example: 999999799
       format: uint64
     spendable_balance:
       type: integer
+      example: 999999799
       format: uint64
     pending_change:
       type: integer
+      example: 0
       format: uint64
     max_send_amount:
       type: integer
+      example: 999999799
       format: uint64
     unspent_coin_count:
       type: integer
+      example: 1
       format: int32
     pending_coin_removal_count:
       type: integer
+      example: 0
       format: int32
     wallet_type:
-      $ref: "./wallet_type.yaml#/wallet_type"
+      $ref: ./wallet_type.yaml#/wallet_type
     asset_id:
       type: string

--- a/src/schemas/wallet_info.yaml
+++ b/src/schemas/wallet_info.yaml
@@ -1,20 +1,24 @@
 wallet_info:
   type: object
-  description: "This object represents the wallet data as it is stored in DB.
-    ID: Main wallet (Standard) is stored at index 1, every wallet created after done has auto incremented id.
-    Name: can be a user provided or default generated name. (can be modified)
-    Type: is specified during wallet creation and should never be changed.
-    Data: this field is intended to be used for storing any wallet specific information required for it.
-    (RL wallet stores origin_id, admin/user pubkey, rate limit, etc.)
-    This data should be a json encoded string."
+  description: "This object represents the wallet data as it is stored in DB. ID:
+    Main wallet (Standard) is stored at index 1, every wallet created after done
+    has auto incremented id. Name: can be a user provided or default generated
+    name. (can be modified) Type: is specified during wallet creation and should
+    never be changed. Data: this field is intended to be used for storing any
+    wallet specific information required for it. (RL wallet stores origin_id,
+    admin/user pubkey, rate limit, etc.) This data should be a json encoded
+    string."
   properties:
     id:
       type: integer
+      example: 1
       format: uint32
     name:
       type: string
+      example: Chia Wallet
     type:
-      $ref: "./wallet_type.yaml#/wallet_type"
+      $ref: ./wallet_type.yaml#/wallet_type
     data:
       type: string
+      example: ""
       format: json

--- a/tools/annotate-with-example.zx.mjs
+++ b/tools/annotate-with-example.zx.mjs
@@ -1,10 +1,22 @@
 #!/usr/bin/env zx
+//
+// This tool takes an example JSON RPC response and the path to a YAML schema, and inserts
+// `example` keys in the appropriate `property` fields of the YAML schema. It was used to
+// generate the example fields in `src/schemas`.
+//
 // See https://github.com/google/zx#install for getting zx
+//
+// cat <<EOF | ./tools/annotate-with-example.zx.mjs src/schemas/network_info.yaml
+// {
+//     "network_name": "mainnet",
+//     "network_prefix": "xch",
+//     "success": true
+// }
+// EOF
 
 const args = argv._
 
 const yamlFile = args[0];
-// const schemasDir = path.dirname(yamlFile);
 const input = await stdin();
 
 const examplesJson = JSON.parse(
@@ -19,25 +31,6 @@ function isRef(record) {
   const keys = Object.keys(record);
   return keys.length === 1 && keys[0] === '$ref';
 }
-
-// /**
-//  * @param {object} record
-//  */
-// async function resolveRef(record) {
-//   const keys = Object.keys(record);
-//   const isRef = keys.length === 1 && keys[0] === '$ref';
-//   if (!isRef) {
-//     return record;
-//   }
-//   console.log(`<${record['$ref']}>`)
-//   const [, filename, , yamlPath] = record['$ref'].match(/^(.*?)(#\/(.*))?$/) || [];
-//   const file = path.join(schemasDir, filename);
-//   const schema = await YAML.parse((await fs.readFile(file)).toString());
-//   const dereferrenced = yamlPath ? get(yamlPath.split('/'), schema) : schema;
-//   console.log(' resolveRef: ', 'filename:', filename, '  yamlPath:', yamlPath)
-//   console.log('  dereferrenced:', dereferrenced)
-//   return dereferrenced;
-// }
 
 const PathError = Symbol('path error')
 

--- a/tools/annotate-with-example.zx.mjs
+++ b/tools/annotate-with-example.zx.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env zx
+// See https://github.com/google/zx#install for getting zx
+
+const args = argv._
+
+const yamlFile = args[0];
+// const schemasDir = path.dirname(yamlFile);
+const input = await stdin();
+
+const examplesJson = JSON.parse(
+  input.replaceAll(/\s+\/\/.*$/mg, '')
+);
+const schema = await YAML.parse((await fs.readFile(yamlFile)).toString());
+
+/**
+ * @param {object} record
+ */
+function isRef(record) {
+  const keys = Object.keys(record);
+  return keys.length === 1 && keys[0] === '$ref';
+}
+
+// /**
+//  * @param {object} record
+//  */
+// async function resolveRef(record) {
+//   const keys = Object.keys(record);
+//   const isRef = keys.length === 1 && keys[0] === '$ref';
+//   if (!isRef) {
+//     return record;
+//   }
+//   console.log(`<${record['$ref']}>`)
+//   const [, filename, , yamlPath] = record['$ref'].match(/^(.*?)(#\/(.*))?$/) || [];
+//   const file = path.join(schemasDir, filename);
+//   const schema = await YAML.parse((await fs.readFile(file)).toString());
+//   const dereferrenced = yamlPath ? get(yamlPath.split('/'), schema) : schema;
+//   console.log(' resolveRef: ', 'filename:', filename, '  yamlPath:', yamlPath)
+//   console.log('  dereferrenced:', dereferrenced)
+//   return dereferrenced;
+// }
+
+const PathError = Symbol('path error')
+
+/**
+ * @param {string[]} path
+ * @param {object} record
+ */
+function get(path, record) {
+  // console.debug(`get(${JSON.stringify(path)}, ${JSON.stringify(record)})`)
+  if (path.length <= 0) {
+    return record;
+  }
+  const [current, ...rest] = path;
+  if (record === null || record === undefined) {
+    throw PathError;
+  }
+  if (!(current in record)) {
+    throw PathError;
+  }
+  return get(rest, record[current]);
+}
+
+
+/**
+ * @param {string[]} path
+ * @param {object} node
+ */
+function traverse(path, node) {
+  const newNode = {};
+  const propertyType = node['type'];
+  for (const [branch, leaf] of Object.entries(node)) {
+    if (Array.isArray(leaf)) {
+      newNode[branch] = leaf.map(item => isRef(item) ? item : traverse([...path, branch], item));
+    } else if (typeof leaf === 'object') {
+      newNode[branch] = isRef(leaf) ? leaf : traverse([...path, branch], leaf);
+      continue;
+    }
+    newNode[branch] = leaf;
+    if (branch === 'type') {
+      if (leaf === 'object') {
+        continue;
+      }
+      const translatedPath = path.filter(p => p !== 'properties').map(p => p === 'items' ? '0' : p);
+      try {
+        const example = get(translatedPath, examplesJson);
+        if (['object', 'array'].includes(typeof example) && example !== null && example !== undefined && propertyType === "string") {
+          console.warn(`${path.join('.')} example is not primitive.`);
+          newNode['example'] = JSON.stringify(example);
+        } else {
+          newNode['example'] = example;
+        }
+      } catch(err) {
+        if (err === PathError) {
+          console.warn(`No example found for ${path.join('.')}`);
+        } else {
+          throw err;
+        }
+      }
+    }
+  }
+  return newNode;
+}
+const rootKeys = Object.keys(schema);
+if (rootKeys.length !== 1) {
+  throw new Error(`Don't know how to handle multiple root keys on schema.`);
+}
+const rootKey = rootKeys[0];
+const newSchema = { [rootKey]: traverse([], schema[rootKey]) };
+const newYamlSchema = YAML.stringify(newSchema, null, 2);
+const destFile = yamlFile.replace('.yaml', '.with-examples.yaml');
+if (destFile === yamlFile) {
+  throw new Error();
+}
+await fs.writeFile(destFile, newYamlSchema)
+console.info(`Wrote to ${destFile}`);


### PR DESCRIPTION
As the name indicates this PR adds examples to the object schemas.

The example were collected and adapted manually from the various Chia RPC docs, so there is the potential for some inaccuracies but from a quick review I didn't spot anything obviously wrong.

Similarly the https://www.npmjs.com/package/yaml parsing modified the formatting slightly.