### PR TITLE
Update $refs for subfolders

### DIFF
--- a/src/crawler.yaml
+++ b/src/crawler.yaml
@@ -25,18 +25,18 @@ security:
 components:
   responses:
     empty:
-      $ref: "./responses/empty.yaml#/empty"
+      $ref: "responses/empty.yaml#/empty"
   requestBodies:
     empty:
-      $ref: "./requestBodies/empty.yaml#/empty"
+      $ref: "requestBodies/empty.yaml#/empty"
   schemas:
     connection_info:
-      $ref: "./schemas/connection_info.yaml#/connection_info"
+      $ref: "schemas/connection_info.yaml#/connection_info"
     apiResponse:
-      $ref: "./schemas/apiResponse.yaml#/apiResponse"
+      $ref: "schemas/apiResponse.yaml#/apiResponse"
   securitySchemes:
     bearerAuth:
-      $ref: "./securitySchemes/bearerAuth.yaml#/bearerAuth"
+      $ref: "securitySchemes/bearerAuth.yaml#/bearerAuth"
 tags:
   - name: Shared
     description: Methods shared by all services.


### PR DESCRIPTION
Removed leading "./" from subfolders in $ref statements. They cause issues in one of my tools when it tries to verify from URL. Here is a link that shows the leader "./" shouldn't be required but plz test with your build tools!!

https://apihandyman.io/writing-openapi-swagger-specification-tutorial-part-8-splitting-specification-file/#folders
