### PR TITLE
Remove leading "./" from $ref statements

### DIFF
--- a/src/crawler.yaml
+++ b/src/crawler.yaml
@@ -25,18 +25,18 @@ security:
 components:
   responses:
     empty:
-      $ref: "./responses/empty.yaml#/empty"
+      $ref: "responses/empty.yaml#/empty"
   requestBodies:
     empty:
-      $ref: "./requestBodies/empty.yaml#/empty"
+      $ref: "requestBodies/empty.yaml#/empty"
   schemas:
     connection_info:
-      $ref: "./schemas/connection_info.yaml#/connection_info"
+      $ref: "schemas/connection_info.yaml#/connection_info"
     apiResponse:
-      $ref: "./schemas/apiResponse.yaml#/apiResponse"
+      $ref: "schemas/apiResponse.yaml#/apiResponse"
   securitySchemes:
     bearerAuth:
-      $ref: "./securitySchemes/bearerAuth.yaml#/bearerAuth"
+      $ref: "securitySchemes/bearerAuth.yaml#/bearerAuth"
 tags:
   - name: Shared
     description: Methods shared by all services.

--- a/src/daemon.yaml
+++ b/src/daemon.yaml
@@ -25,27 +25,27 @@ security:
 components:
   requestBodies:
     empty:
-      $ref: "./requestBodies/empty.yaml#/empty"
+      $ref: "requestBodies/empty.yaml#/empty"
     service:
-      $ref: "./requestBodies/service.yaml#/service"
+      $ref: "requestBodies/service.yaml#/service"
   responses:
     empty:
-      $ref: "./responses/empty.yaml#/empty"
+      $ref: "responses/empty.yaml#/empty"
   schemas:
     k_size:
-      $ref: "./schemas/k_size.yaml#/k_size"
+      $ref: "schemas/k_size.yaml#/k_size"
     key_data:
-      $ref: "./schemas/key_data.yaml#/key_data"
+      $ref: "schemas/key_data.yaml#/key_data"
     plotter_config:
-      $ref: "./schemas/plotter_config.yaml#/plotter_config"
+      $ref: "schemas/plotter_config.yaml#/plotter_config"
     plotter_info:
-      $ref: "./schemas/plotter_info.yaml#/plotter_info"
+      $ref: "schemas/plotter_info.yaml#/plotter_info"
     queued_plot_info:
-      $ref: "./schemas/queued_plot_info.yaml#/queued_plot_info"
+      $ref: "schemas/queued_plot_info.yaml#/queued_plot_info"
     apiResponse:
-      $ref: "./schemas/apiResponse.yaml#/apiResponse"
+      $ref: "schemas/apiResponse.yaml#/apiResponse"
     error_details:
-      $ref: "./schemas/error_details.yaml#/error_details"
+      $ref: "schemas/error_details.yaml#/error_details"
     keyring_status:
       type: object
       properties:
@@ -81,7 +81,7 @@ components:
           type: string
   securitySchemes:
     bearerAuth:
-      $ref: "./securitySchemes/bearerAuth.yaml#/bearerAuth"
+      $ref: "securitySchemes/bearerAuth.yaml#/bearerAuth"
 tags:
   - name: Daemon
     description: The daemon interface is exposed on port 55400 by default and uses WebSockets only. It can be used to interact with other service endpoints.

--- a/src/data_layer.yaml
+++ b/src/data_layer.yaml
@@ -25,32 +25,32 @@ security:
 components:
   requestBodies:
     empty:
-      $ref: "./requestBodies/empty.yaml#/empty"
+      $ref: "requestBodies/empty.yaml#/empty"
   responses:
     empty:
-      $ref: "./responses/empty.yaml#/empty"
+      $ref: "responses/empty.yaml#/empty"
   schemas:
     connection_info:
-      $ref: "./schemas/connection_info.yaml#/connection_info"
+      $ref: "schemas/connection_info.yaml#/connection_info"
     internal_node:
-      $ref: "./schemas/internal_node.yaml#/internal_node"
+      $ref: "schemas/internal_node.yaml#/internal_node"
     mirror:
-      $ref: "./schemas/mirror.yaml#/mirror"
+      $ref: "schemas/mirror.yaml#/mirror"
     offer:
-      $ref: "./schemas/offer.yaml#/offer"
+      $ref: "schemas/offer.yaml#/offer"
     offer_store:
-      $ref: "./schemas/offer_store.yaml#/offer_store"
+      $ref: "schemas/offer_store.yaml#/offer_store"
     plugin_status:
-      $ref: "./schemas/plugin_status.yaml#/plugin_status"
+      $ref: "schemas/plugin_status.yaml#/plugin_status"
     terminal_node:
-      $ref: "./schemas/terminal_node.yaml#/terminal_node"
+      $ref: "schemas/terminal_node.yaml#/terminal_node"
     transaction_record:
-      $ref: "./schemas/transaction_record.yaml#/transaction_record"
+      $ref: "schemas/transaction_record.yaml#/transaction_record"
     apiResponse:
-      $ref: "./schemas/apiResponse.yaml#/apiResponse"
+      $ref: "schemas/apiResponse.yaml#/apiResponse"
   securitySchemes:
     bearerAuth:
-      $ref: "./securitySchemes/bearerAuth.yaml#/bearerAuth"
+      $ref: "securitySchemes/bearerAuth.yaml#/bearerAuth"
 tags:
   - name: Shared
     description: Methods shared by all services.

--- a/src/farmer.yaml
+++ b/src/farmer.yaml
@@ -25,29 +25,29 @@ security:
 components:
   requestBodies:
     empty:
-      $ref: "./requestBodies/empty.yaml#/empty"
+      $ref: "requestBodies/empty.yaml#/empty"
   responses:
     empty:
-      $ref: "./responses/empty.yaml#/empty"
+      $ref: "responses/empty.yaml#/empty"
   schemas:
     connection_info:
-      $ref: "./schemas/connection_info.yaml#/connection_info"
+      $ref: "schemas/connection_info.yaml#/connection_info"
     harvester_info:
-      $ref: "./schemas/harvester_info.yaml#/harvester_info"
+      $ref: "schemas/harvester_info.yaml#/harvester_info"
     harvester_summary:
-      $ref: "./schemas/harvester_summary.yaml#/harvester_summary"
+      $ref: "schemas/harvester_summary.yaml#/harvester_summary"
     paginated_plot_request:
-      $ref: "./schemas/paginated_plot_request.yaml#/paginated_plot_request"
+      $ref: "schemas/paginated_plot_request.yaml#/paginated_plot_request"
     pool_state_info:
-      $ref: "./schemas/pool_state_info.yaml#/pool_state_info"
+      $ref: "schemas/pool_state_info.yaml#/pool_state_info"
     plot_info_request_data:
-      $ref: "./schemas/plot_info_request_data.yaml#/plot_info_request_data"
+      $ref: "schemas/plot_info_request_data.yaml#/plot_info_request_data"
     plot_path_request_data:
-      $ref: "./schemas/plot_path_request_data.yaml#/plot_path_request_data"
+      $ref: "schemas/plot_path_request_data.yaml#/plot_path_request_data"
     proof_of_space:
-      $ref: "./schemas/proof_of_space.yaml#/proof_of_space"
+      $ref: "schemas/proof_of_space.yaml#/proof_of_space"
     farmer_signage_point:
-      $ref: "./schemas/farmer_signage_point.yaml#/farmer_signage_point"
+      $ref: "schemas/farmer_signage_point.yaml#/farmer_signage_point"
     signage_point_bundle:
       type: object
       properties:
@@ -68,10 +68,10 @@ components:
             minItems: 2
             maxItems: 2
     apiResponse:
-      $ref: "./schemas/apiResponse.yaml#/apiResponse"
+      $ref: "schemas/apiResponse.yaml#/apiResponse"
   securitySchemes:
     bearerAuth:
-      $ref: "./securitySchemes/bearerAuth.yaml#/bearerAuth"
+      $ref: "securitySchemes/bearerAuth.yaml#/bearerAuth"
 tags:
   - name: Shared
     description: Methods shared by all services.

--- a/src/full_node.yaml
+++ b/src/full_node.yaml
@@ -25,7 +25,7 @@ security:
 components:
   requestBodies:
     empty:
-      $ref: "./requestBodies/empty.yaml#/empty"
+      $ref: "requestBodies/empty.yaml#/empty"
     header_hash:
       required: true
       description: the block's header_hash
@@ -58,7 +58,7 @@ components:
                 format: uint32
   responses:
     empty:
-      $ref: "./responses/empty.yaml#/empty"
+      $ref: "responses/empty.yaml#/empty"
     coin_records:
       description: OK
       content:
@@ -74,15 +74,15 @@ components:
               - $ref: "#/components/schemas/apiResponse"
   schemas:
     proof_of_space:
-      $ref: "./schemas/proof_of_space.yaml#/proof_of_space"
+      $ref: "schemas/proof_of_space.yaml#/proof_of_space"
     blockchain_state:
-      $ref: "./schemas/blockchain_state.yaml#/blockchain_state"
+      $ref: "schemas/blockchain_state.yaml#/blockchain_state"
     block_record:
-      $ref: "./schemas/block_record.yaml#/block_record"
+      $ref: "schemas/block_record.yaml#/block_record"
     coin:
-      $ref: "./schemas/coin.yaml#/coin"
+      $ref: "schemas/coin.yaml#/coin"
     coin_record:
-      $ref: "./schemas/coin_record.yaml#/coin_record"
+      $ref: "schemas/coin_record.yaml#/coin_record"
     coin_search_options:
       type: object
       properties:
@@ -95,38 +95,38 @@ components:
         include_spent_coins:
           type: boolean
     coin_spend:
-      $ref: "./schemas/coin_spend.yaml#/coin_spend"
+      $ref: "schemas/coin_spend.yaml#/coin_spend"
     connection_info:
-      $ref: "./schemas/connection_info.yaml#/connection_info"
+      $ref: "schemas/connection_info.yaml#/connection_info"
     foliage:
-      $ref: "./schemas/foliage.yaml#/foliage"
+      $ref: "schemas/foliage.yaml#/foliage"
     foliage_transaction_block:
-      $ref: "./schemas/foliage_transaction_block.yaml#/foliage_transaction_block"
+      $ref: "schemas/foliage_transaction_block.yaml#/foliage_transaction_block"
     full_block:
-      $ref: "./schemas/full_block.yaml#/full_block"
+      $ref: "schemas/full_block.yaml#/full_block"
     end_of_sub_slot_bundle:
-      $ref: "./schemas/end_of_sub_slot_bundle.yaml#/end_of_sub_slot_bundle"
+      $ref: "schemas/end_of_sub_slot_bundle.yaml#/end_of_sub_slot_bundle"
     mempool_item:
-      $ref: "./schemas/mempool_item.yaml#/mempool_item"
+      $ref: "schemas/mempool_item.yaml#/mempool_item"
     network_info:
-      $ref: "./schemas/network_info.yaml#/network_info"
+      $ref: "schemas/network_info.yaml#/network_info"
     node_type:
-      $ref: "./schemas/node_type.yaml#/node_type"
+      $ref: "schemas/node_type.yaml#/node_type"
     signage_point:
-      $ref: "./schemas/signage_point.yaml#/signage_point"
+      $ref: "schemas/signage_point.yaml#/signage_point"
     spend_bundle:
-      $ref: "./schemas/spend_bundle.yaml#/spend_bundle"
+      $ref: "schemas/spend_bundle.yaml#/spend_bundle"
     unfinished_header_block:
-      $ref: "./schemas/unfinished_header_block.yaml#/unfinished_header_block"
+      $ref: "schemas/unfinished_header_block.yaml#/unfinished_header_block"
     apiResponse:
-      $ref: "./schemas/apiResponse.yaml#/apiResponse"
+      $ref: "schemas/apiResponse.yaml#/apiResponse"
     vdf_info:
-      $ref: "./schemas/vdf_info.yaml#/vdf_info"
+      $ref: "schemas/vdf_info.yaml#/vdf_info"
     vdf_proof:
-      $ref: "./schemas/vdf_proof.yaml#/vdf_proof"
+      $ref: "schemas/vdf_proof.yaml#/vdf_proof"
   securitySchemes:
     bearerAuth:
-      $ref: "./securitySchemes/bearerAuth.yaml#/bearerAuth"
+      $ref: "securitySchemes/bearerAuth.yaml#/bearerAuth"
 tags:
   - name: Blocks
     description: Methods for managing blocks.

--- a/src/harvester.yaml
+++ b/src/harvester.yaml
@@ -25,22 +25,22 @@ security:
 components:
   requestBodies:
     empty:
-      $ref: "./requestBodies/empty.yaml#/empty"
+      $ref: "requestBodies/empty.yaml#/empty"
   responses:
     empty:
-      $ref: "./responses/empty.yaml#/empty"
+      $ref: "responses/empty.yaml#/empty"
   schemas:
     connection_info:
-      $ref: "./schemas/connection_info.yaml#/connection_info"
+      $ref: "schemas/connection_info.yaml#/connection_info"
     k_size:
-      $ref: "./schemas/k_size.yaml#/k_size"
+      $ref: "schemas/k_size.yaml#/k_size"
     plot_info:
-      $ref: "./schemas/plot_info.yaml#/plot_info"
+      $ref: "schemas/plot_info.yaml#/plot_info"
     apiResponse:
-      $ref: "./schemas/apiResponse.yaml#/apiResponse"
+      $ref: "schemas/apiResponse.yaml#/apiResponse"
   securitySchemes:
     bearerAuth:
-      $ref: "./securitySchemes/bearerAuth.yaml#/bearerAuth"
+      $ref: "securitySchemes/bearerAuth.yaml#/bearerAuth"
 tags:
   - name: Shared
     description: Methods shared by all services.

--- a/src/wallet.yaml
+++ b/src/wallet.yaml
@@ -25,16 +25,16 @@ security:
 components:
   requestBodies:
     empty:
-      $ref: "./requestBodies/empty.yaml#/empty"
+      $ref: "requestBodies/empty.yaml#/empty"
     fingerprint:
-      $ref: "./requestBodies/fingerprint.yaml#/fingerprint"
+      $ref: "requestBodies/fingerprint.yaml#/fingerprint"
     wallet_id:
-      $ref: "./requestBodies/wallet_id.yaml#/wallet_id"
+      $ref: "requestBodies/wallet_id.yaml#/wallet_id"
     transaction_id:
-      $ref: "./requestBodies/transaction_id.yaml#/transaction_id"
+      $ref: "requestBodies/transaction_id.yaml#/transaction_id"
   responses:
     empty:
-      $ref: "./responses/empty.yaml#/empty"
+      $ref: "responses/empty.yaml#/empty"
     coin_records:
       description: OK
       content:
@@ -76,13 +76,13 @@ components:
               - $ref: "#/components/schemas/apiResponse"
   schemas:
     amount_filter:
-      $ref: "./schemas/amount_filter.yaml#/amount_filter"
+      $ref: "schemas/amount_filter.yaml#/amount_filter"
     amount_with_puzzlehash:
-      $ref: "./schemas/amount_with_puzzlehash.yaml#/amount_with_puzzlehash"
+      $ref: "schemas/amount_with_puzzlehash.yaml#/amount_with_puzzlehash"
     coin_announcement:
-      $ref: "./schemas/coin_announcement.yaml#/coin_announcement"
+      $ref: "schemas/coin_announcement.yaml#/coin_announcement"
     coin_record_order:
-      $ref: "./schemas/coin_record_order.yaml#/coin_record_order"
+      $ref: "schemas/coin_record_order.yaml#/coin_record_order"
     coin_search_options:
       type: object
       properties:
@@ -95,70 +95,70 @@ components:
         include_spent_coins:
           type: boolean
     coin_type:
-      $ref: "./schemas/coin_type.yaml#/coin_type"
+      $ref: "schemas/coin_type.yaml#/coin_type"
     connection_info:
-      $ref: "./schemas/connection_info.yaml#/connection_info"
+      $ref: "schemas/connection_info.yaml#/connection_info"
     puzzle_announcement:
-      $ref: "./schemas/puzzle_announcement.yaml#/puzzle_announcement"
+      $ref: "schemas/puzzle_announcement.yaml#/puzzle_announcement"
     cat_info:
-      $ref: "./schemas/cat_info.yaml#/cat_info"
+      $ref: "schemas/cat_info.yaml#/cat_info"
     coin:
-      $ref: "./schemas/coin.yaml#/coin"
+      $ref: "schemas/coin.yaml#/coin"
     coin_record:
-      $ref: "./schemas/coin_record.yaml#/coin_record"
+      $ref: "schemas/coin_record.yaml#/coin_record"
     farmer_rewards:
-      $ref: "./schemas/farmer_rewards.yaml#/farmer_rewards"
+      $ref: "schemas/farmer_rewards.yaml#/farmer_rewards"
     hash_filter:
-      $ref: "./schemas/hash_filter.yaml#/hash_filter"
+      $ref: "schemas/hash_filter.yaml#/hash_filter"
     lineage_proof:
-      $ref: "./schemas/lineage_proof.yaml#/lineage_proof"
+      $ref: "schemas/lineage_proof.yaml#/lineage_proof"
     mirror:
-      $ref: "./schemas/mirror.yaml#/mirror"
+      $ref: "schemas/mirror.yaml#/mirror"
     mnemonic:
-      $ref: "./schemas/mnemonic.yaml#/mnemonic"
+      $ref: "schemas/mnemonic.yaml#/mnemonic"
     network_info:
-      $ref: "./schemas/network_info.yaml#/network_info"
+      $ref: "schemas/network_info.yaml#/network_info"
     nft_info:
-      $ref: "./schemas/nft_info.yaml#/nft_info"
+      $ref: "schemas/nft_info.yaml#/nft_info"
     pool_state:
-      $ref: "./schemas/pool_state.yaml#/pool_state"
+      $ref: "schemas/pool_state.yaml#/pool_state"
     pool_wallet_info:
-      $ref: "./schemas/pool_wallet_info.yaml#/pool_wallet_info"
+      $ref: "schemas/pool_wallet_info.yaml#/pool_wallet_info"
     private_key:
-      $ref: "./schemas/private_key.yaml#/private_key"
+      $ref: "schemas/private_key.yaml#/private_key"
     singleton_record:
-      $ref: "./schemas/singleton_record.yaml#/singleton_record"
+      $ref: "schemas/singleton_record.yaml#/singleton_record"
     spend_bundle:
-      $ref: "./schemas/spend_bundle.yaml#/spend_bundle"
+      $ref: "schemas/spend_bundle.yaml#/spend_bundle"
     token:
-      $ref: "./schemas/token.yaml#/token"
+      $ref: "schemas/token.yaml#/token"
     trade_record:
-      $ref: "./schemas/trade_record.yaml#/trade_record"
+      $ref: "schemas/trade_record.yaml#/trade_record"
     transaction_record:
-      $ref: "./schemas/transaction_record.yaml#/transaction_record"
+      $ref: "schemas/transaction_record.yaml#/transaction_record"
     transaction_type:
-      $ref: "./schemas/transaction_type.yaml#/transaction_type"
+      $ref: "schemas/transaction_type.yaml#/transaction_type"
     transaction_type_filter:
-      $ref: "./schemas/transaction_type_filter.yaml#/transaction_type_filter"
+      $ref: "schemas/transaction_type_filter.yaml#/transaction_type_filter"
     uint32_range:
-      $ref: "./schemas/uint32_range.yaml#/uint32_range"
+      $ref: "schemas/uint32_range.yaml#/uint32_range"
     uint64_range:
-      $ref: "./schemas/uint64_range.yaml#/uint64_range"
+      $ref: "schemas/uint64_range.yaml#/uint64_range"
     vc_proofs:
-      $ref: "./schemas/vc_proofs.yaml#/vc_proofs"
+      $ref: "schemas/vc_proofs.yaml#/vc_proofs"
     vc_record:
-      $ref: "./schemas/vc_record.yaml#/vc_record"
+      $ref: "schemas/vc_record.yaml#/vc_record"
     wallet_balance:
-      $ref: "./schemas/wallet_balance.yaml#/wallet_balance"
+      $ref: "schemas/wallet_balance.yaml#/wallet_balance"
     wallet_info:
-      $ref: "./schemas/wallet_info.yaml#/wallet_info"
+      $ref: "schemas/wallet_info.yaml#/wallet_info"
     wallet_type:
-      $ref: "./schemas/wallet_type.yaml#/wallet_type"
+      $ref: "schemas/wallet_type.yaml#/wallet_type"
     apiResponse:
-      $ref: "./schemas/apiResponse.yaml#/apiResponse"
+      $ref: "schemas/apiResponse.yaml#/apiResponse"
   securitySchemes:
     bearerAuth:
-      $ref: "./securitySchemes/bearerAuth.yaml#/bearerAuth"
+      $ref: "securitySchemes/bearerAuth.yaml#/bearerAuth"
 tags:
   - name: Shared
     description: Methods shared by all services.


### PR DESCRIPTION
Removed leading "./" from subfolders in $ref statements. They cause issues in one of my tools when it tries to verify from URL. Here is a link that shows the leader "./" shouldn't be required but plz test with your build tools!!

https://apihandyman.io/writing-openapi-swagger-specification-tutorial-part-8-splitting-specification-file/#folders